### PR TITLE
Set url_key field type to keyword

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Eav/Abstract.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Eav/Abstract.php
@@ -18,7 +18,8 @@ abstract class Divante_VueStorefrontIndexer_Model_Index_Mapping_Eav_Abstract
      * @var array
      */
     protected $longProperties = [
-        'category_ids'
+        'category_ids',
+        'level'
     ];
 
     /**

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Eav/Abstract.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Eav/Abstract.php
@@ -14,6 +14,20 @@ use Divante_VueStorefrontIndexer_Api_Mapping_FieldInterface as FieldInterface;
  */
 abstract class Divante_VueStorefrontIndexer_Model_Index_Mapping_Eav_Abstract
 {
+    /**
+     * @var array
+     */
+    protected $longProperties = [
+        'category_ids'
+    ];
+
+    /**
+     * @var array
+     */
+    protected $keywordProperties = [
+        'sku',
+        'url_key'
+    ];
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav
@@ -90,15 +104,11 @@ abstract class Divante_VueStorefrontIndexer_Model_Index_Mapping_Eav_Abstract
     {
         $attributeCode = $attribute->getAttributeCode();
 
-        if ('category_ids' === $attributeCode) {
-            return FieldInterface::TYPE_LONG;
-        }
-
-        if ('sku' === $attributeCode) {
+        if (in_array($attributeCode, $this->keywordProperties)) {
             return FieldInterface::TYPE_KEYWORD;
         }
 
-        if ('level' === $attributeCode) {
+        if (in_array($attributeCode, $this->longProperties)) {
             return FieldInterface::TYPE_LONG;
         }
 


### PR DESCRIPTION
Url identifier should not be analyzed by elasticsearch in order to find a matching entry.
This fixes issues in requests for url keys that contain special chars, which could not be found.