### PR TITLE
Index cms pages

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Cms/Page.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Cms/Page.php
@@ -1,0 +1,61 @@
+<?php
+
+use Divante_VueStorefrontIndexer_Api_MappingInterface as MappingInterface;
+use Divante_VueStorefrontIndexer_Api_Mapping_FieldInterface as FieldInterface;
+
+/**
+ * Class Divante_VueStorefrontIndexer_Model_Index_Mapping_Cms_Page
+ *
+ * @package     Divante
+ * @category    VueStoreFrontIndexer
+ * @author      Sven Ehmer <sven.ehmer@gastro-hero.de>
+ * @copyright   Copyright (C) 2018 Divante Sp. z o.o.
+ * @license     See LICENSE_DIVANTE.txt for license details.
+ */
+class Divante_VueStorefrontIndexer_Model_Index_Mapping_Cms_Page implements MappingInterface
+{
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @inheritdoc
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMappingProperties()
+    {
+        $properties = [
+            'id' => ['type' => FieldInterface::TYPE_LONG],
+            'content' => ['type' => FieldInterface::TYPE_TEXT],
+            'is_active' => ['type' => FieldInterface::TYPE_BOOLEAN],
+            'title' => ['type' => FieldInterface::TYPE_TEXT],
+            'identifier' => [
+                'type' => FieldInterface::TYPE_TEXT,
+                'fields' => ['keyword' => ['type' => FieldInterface::TYPE_KEYWORD]]
+            ]
+        ];
+
+        $mapping = ['properties' => $properties];
+
+        $mappingObject = new Varien_Object($mapping);
+        Mage::dispatchEvent('elasticsearch_cms_page_mapping_properties', ['mapping' => $mappingObject]);
+
+        return $mappingObject->getData();
+    }
+}

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Cms/Page.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Cms/Page.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Class Divante_VueStorefrontIndexer_Model_Indexer_Action_Cms_Page
+ *
+ * @package     Divante
+ * @category    VueStoreFrontIndexer
+ * @author      Sven Ehmer <sven.ehmer@gastro-hero.de>
+ * @copyright   Copyright (C) 2018 Divante Sp. z o.o.
+ * @license     See LICENSE_DIVANTE.txt for license details.
+ */
+class Divante_VueStorefrontIndexer_Model_Indexer_Action_Cms_Page
+{
+    /**
+     * @var Divante_VueStorefrontIndexer_Model_Resource_Cms_Page
+     */
+    protected $resourceModel;
+
+    /**
+     * @var Varien_Filter_Template
+     */
+    protected $pageTemplateProcessor;
+
+    public function __construct()
+    {
+        $this->resourceModel = Mage::getResourceModel('vsf_indexer/cms_page');
+        /* @var $helper Mage_Cms_Helper_Data */
+        $helper = Mage::helper('cms');
+        $this->pageTemplateProcessor = $helper->getPageTemplateProcessor();
+    }
+
+    /**
+     * @param int   $storeId
+     * @param array $pageIds
+     *
+     * @return \Traversable
+     */
+    public function rebuild($storeId = 1, array $pageIds = [])
+    {
+        $lastPageId = 0;
+
+        do {
+            $cmsPages = $this->resourceModel->loadPages($storeId, $pageIds, $lastPageId);
+
+            foreach ($cmsPages as $pageData) {
+                $lastPageId = $pageData['page_id'];
+                $pageData['id'] = $pageData['page_id'];
+                $pageData['content'] = $this->pageTemplateProcessor->filter($pageData['content']);
+
+                unset($pageData['creation_time'], $pageData['update_time'], $pageData['page_id']);
+
+                yield $lastPageId => $pageData;
+            }
+        } while (!empty($cmsPages));
+    }
+}

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Cms/Pages.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Cms/Pages.php
@@ -1,0 +1,87 @@
+<?php
+
+use Divante_VueStorefrontIndexer_Api_IndexerInterface as IndexerInterface;
+use Divante_VueStorefrontIndexer_Model_Indexer_Action_Cms_Page as Action;
+use Divante_VueStorefrontIndexer_Model_ElasticSearch_Indexer_Handler as IndexerHandler;
+use Divante_VueStorefrontIndexer_Model_Indexer_Helper_Store as StoreHelper;
+use Mage_Core_Model_Store as Store;
+
+/**
+ * Class Divante_VueStorefrontIndexer_Model_Indexer_Cms_Pages
+ *
+ * @package     Divante
+ * @category    VueStoreFrontIndexer
+ * @author      Sven Ehmer <sven.ehmer@gastro-hero.de>
+ * @copyright   Copyright (C) 2018 Divante Sp. z o.o.
+ * @license     See LICENSE_DIVANTE.txt for license details.
+ */
+class Divante_VueStorefrontIndexer_Model_Indexer_Cms_Pages implements IndexerInterface
+{
+    const TYPE = 'cms_page';
+
+    /**
+     * @var IndexerHandler
+     */
+    protected $indexHandler;
+
+    /**
+     * @var Action
+     */
+    protected $action;
+
+    /**
+     * @var StoreHelper
+     */
+    protected $storeHelper;
+    
+    public function __construct()
+    {
+        $this->indexHandler = Mage::getModel(
+            'vsf_indexer/elasticsearch_indexer_handler',
+            [
+                'type_name' => self::TYPE,
+                'index_identifier' => 'vue_storefront_catalog',
+            ]
+        );
+
+        $this->action = Mage::getSingleton('vsf_indexer/indexer_action_cms_page');
+        $this->storeHelper = Mage::getSingleton('vsf_indexer/indexer_helper_store');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function updateDocuments($storeId = null, array $ids = [])
+    {
+        $stores = $this->storeHelper->getStores($storeId);
+
+        /** @var Store $store */
+        foreach ($stores as $store) {
+            $this->indexHandler->saveIndex($this->action->rebuild($store->getId(), $ids), $store);
+            $this->indexHandler->cleanUpByTransactionKey($store, $ids);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function deleteDocuments($storeId = null, array $ids)
+    {
+        $stores = $this->storeHelper->getStores($storeId);
+
+        if (!empty($ids)) {
+            /** @var Store $store */
+            foreach ($stores as $store) {
+                $this->indexHandler->deleteDocuments($ids, $store);
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTypeName()
+    {
+        return self::TYPE;
+    }
+}

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Cms/Page/Delete.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Cms/Page/Delete.php
@@ -1,0 +1,59 @@
+<?php
+
+use Divante_VueStorefrontIndexer_Model_Event_Handler as EventHandler;
+use Divante_VueStorefrontIndexer_Model_Indexer_Cms_Pages as PagesIndexer;
+use Mage_Cms_Model_Page as CmsPage;
+
+/**
+ * Class Divante_VueStorefrontIndexer_Model_Observer_Event_Cms_Page_Delete
+ *
+ * @package     Divante
+ * @category    VueStoreFrontIndexer
+ * @author      Sven Ehmer <sven.ehmer@gastro-hero.de>
+ * @copyright   Copyright (C) 2018 Divante Sp. z o.o.
+ * @license     See LICENSE_DIVANTE.txt for license details.
+ */
+class Divante_VueStorefrontIndexer_Model_Observer_Event_Cms_Page_Delete
+{
+    /**
+     * @var EventHandler
+     */
+    protected $eventHandler;
+
+    /**
+     * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.
+     */
+    public function __construct()
+    {
+        $this->eventHandler = Mage::getSingleton('vsf_indexer/event_handler');
+    }
+
+    /**
+     * @param Varien_Event_Observer $observer
+     */
+    public function execute(Varien_Event_Observer $observer)
+    {
+        $dataObject = $observer->getEvent()->getData('page');
+        $status = $observer->getEvent()->getData('status');
+
+        if ($dataObject instanceof CmsPage && $status === 'success') {
+            $this->logEvent(
+                $dataObject->getId(),
+                PagesIndexer::TYPE,
+                'delete'
+            );
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function logEvent($id, $entityType, $eventType)
+    {
+        $this->eventHandler->logEvent(
+            $id,
+            $entityType,
+            $eventType
+        );
+    }
+}

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Cms/Page/Save.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Cms/Page/Save.php
@@ -1,0 +1,67 @@
+<?php
+
+use Divante_VueStorefrontIndexer_Model_Event_Handler as EventHandler;
+use Divante_VueStorefrontIndexer_Model_Indexer_Cms_Pages as PagesIndexer;
+use Mage_Cms_Model_Page as CmsPage;
+
+/**
+ * Class Divante_VueStorefrontIndexer_Model_Observer_Event_Cms_Page_Save
+ *
+ * @package     Divante
+ * @category    VueStoreFrontIndexer
+ * @author      Sven Ehmer <sven.ehmer@gastro-hero.de>
+ * @copyright   Copyright (C) 2018 Divante Sp. z o.o.
+ * @license     See LICENSE_DIVANTE.txt for license details.
+ */
+class Divante_VueStorefrontIndexer_Model_Observer_Event_Cms_Page_Save
+{
+    /**
+     * @var EventHandler
+     */
+    protected $eventHandler;
+
+    /**
+     * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.
+     */
+    public function __construct()
+    {
+        $this->eventHandler = Mage::getSingleton('vsf_indexer/event_handler');
+    }
+
+    /**
+     * @param Varien_Event_Observer $observer
+     */
+    public function execute(Varien_Event_Observer $observer)
+    {
+        $cmsPage = $observer->getEvent()->getData('page');
+
+        if ($cmsPage instanceof CmsPage) {
+            if ($cmsPage->getIsActive()) {
+
+                $this->logEvent(
+                    $cmsPage->getId(),
+                    PagesIndexer::TYPE,
+                    'save'
+                );
+            } else {
+                $this->logEvent(
+                    $cmsPage->getId(),
+                    PagesIndexer::TYPE,
+                    'delete'
+                );
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function logEvent($id, $entityType, $eventType)
+    {
+        $this->eventHandler->logEvent(
+            $id,
+            $entityType,
+            $eventType
+        );
+    }
+}

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Cms/Page.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Cms/Page.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Class Divante_VueStorefrontIndexer_Model_Resource_Cms_Page
+ *
+ * @package     Divante
+ * @category    VueStoreFrontIndexer
+ * @author      Sven Ehmer <sven.ehmer@gastro-hero.de>
+ * @copyright   Copyright (C) 2018 Divante Sp. z o.o.
+ * @license     See LICENSE_DIVANTE.txt for license details.
+ */
+class Divante_VueStorefrontIndexer_Model_Resource_Cms_Page
+{
+    /**
+     * @var Mage_Core_Model_Resource
+     */
+    protected $coreResource;
+
+    /**
+     * @var Varien_Db_Adapter_Interface
+     */
+    protected $connection;
+    
+    public function __construct()
+    {
+        $this->coreResource = Mage::getSingleton('core/resource');
+        $this->connection = $this->coreResource->getConnection('read');
+    }
+
+    /**
+     * @param int $storeId
+     * @param array $pageIds
+     * @param int   $fromId
+     * @param int   $limit
+     *
+     * @return array
+     */
+    public function loadPages($storeId = 1, array $pageIds = [], $fromId = 0, $limit = 100)
+    {
+        $select = $this->connection->select()->from(['main_table' => $this->coreResource->getTableName('cms/page')]);
+        $select->join(
+            ['store_table' => $this->coreResource->getTableName('cms/page_store')],
+            'main_table.page_id = store_table.page_id',
+            []
+        )->group('main_table.page_id');
+
+        $select->where('store_table.store_id IN (?)', [0, $storeId]);
+
+        if (!empty($pageIds)) {
+            $select->where('main_table.page_id IN (?)', $pageIds);
+        }
+
+        $select->where('is_active = ?', 1);
+        $select->where('main_table.page_id > ?', $fromId)
+            ->limit($limit)
+            ->order('main_table.page_id');
+
+        return $this->connection->fetchAll($select);
+    }
+}

--- a/src/app/code/community/Divante/VueStorefrontIndexer/etc/config.xml
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/etc/config.xml
@@ -164,6 +164,22 @@
                     </vsf_indexer_product>
                 </observers>
             </core_abstract_save_delete>
+            <cms_page_prepare_save>
+                <observers>
+                    <vsf_indexer_product>
+                        <class>vsf_indexer/observer_event_cms_page_save</class>
+                        <method>execute</method>
+                    </vsf_indexer_product>
+                </observers>
+            </cms_page_prepare_save>
+            <adminhtml_cmspage_on_delete>
+                <observers>
+                    <vsf_indexer_product>
+                        <class>vsf_indexer/observer_event_cms_page_delete</class>
+                        <method>execute</method>
+                    </vsf_indexer_product>
+                </observers>
+            </adminhtml_cmspage_on_delete>
         </events>
     </adminhtml>
     <global>
@@ -213,6 +229,12 @@
                                 <transaction_key>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Transactionkey</transaction_key>
                             </datasources>
                         </cms_block>
+                        <cms_page>
+                            <mapping>Divante_VueStorefrontIndexer_Model_Index_Mapping_Cms_Page</mapping>
+                            <datasources>
+                                <transaction_key>Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Transactionkey</transaction_key>
+                            </datasources>
+                        </cms_page>
                     </types>
                 </vue_storefront_catalog>
             </indices_config>
@@ -230,6 +252,9 @@
                 <cms_blocks>
                     <class>Divante_VueStorefrontIndexer_Model_Indexer_Cms_Blocks</class>
                 </cms_blocks>
+                <cms_pages>
+                    <class>Divante_VueStorefrontIndexer_Model_Indexer_Cms_Pages</class>
+                </cms_pages>
                 <taxrules>
                     <class>Divante_VueStorefrontIndexer_Model_Indexer_Taxrules</class>
                 </taxrules>


### PR DESCRIPTION
The cms page indexing is nearly 1:1 based on the already available cms block indexing.
One thing to mention is, that the cms page events dispatched in magento 1.9 do not provide necessary data to identify a entity in the observers, therefore the event data need to be extended manually.