### PR TITLE
Issue #12: Use native price logic for configurable products as default

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/etc/config.xml
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/etc/config.xml
@@ -266,7 +266,7 @@
             </redis_cache_settings>
             <catalog_settings>
                 <use_magento_url_keys>0</use_magento_url_keys>
-                <configurable_children_use_simple_price>1</configurable_children_use_simple_price>
+                <configurable_children_use_simple_price>0</configurable_children_use_simple_price>
             </catalog_settings>
         </vuestorefront>
     </default>


### PR DESCRIPTION
Resolves issue #12 by changing default value for `configurable_children_use_simple_price` from `1` to `0`.

Until now the `configurable_children_use_simple_price` default value was set to `1` which resulted in a different price logic than Magento 1 normally use for configurable products. As a Magento developer quite new to Vue Storefront I rather see the default logic being used as default and let the customization be something that needs an active decision.