### PR TITLE
Product image inheritance

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Config/Catalogsettings.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Config/Catalogsettings.php
@@ -30,6 +30,14 @@ class Divante_VueStorefrontIndexer_Model_Config_Catalogsettings
     }
 
     /**
+     * @return bool
+     */
+    public function useImageInheritanceForConfigurableChildren()
+    {
+        return (bool)$this->getConfigParam('configurable_children_use_image_inheritance');
+    }
+
+    /**
      * @param int $storeId
      * @return array
      */

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Configurable.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Configurable.php
@@ -44,6 +44,15 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
         'tax_class_id',
     ];
     /**
+     * Images
+     * @var array
+     */
+    private $imageAttributes = [
+        'image',
+        'small_image',
+        'thumbnail'
+    ];
+    /**
      * @var Divante_VueStorefrontIndexer_Model_Data_Filter
      */
     private $dataFilter;
@@ -152,6 +161,18 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
 
                 if (!isset($indexData[$parentId]['configurable_options'])) {
                     $indexData[$parentId]['configurable_options'] = [];
+                }
+
+                if ($this->configSettings->useImageInheritanceForConfigurableChildren()) {
+                    foreach ($this->imageAttributes as $code) {
+                        if ((!array_key_exists($code, $child)
+                            || !$child[$code]
+                            || $child[$code] == 'no_selection')
+                            && array_key_exists($code, $indexData[$parentId])
+                        ) {
+                            $child[$code] = $indexData[$parentId][$code];
+                        }
+                    }
                 }
 
                 if (!$this->configSettings->useSimplePriceForConfigurableChildren()) {

--- a/src/app/code/community/Divante/VueStorefrontIndexer/etc/system.xml
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/etc/system.xml
@@ -232,8 +232,16 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </use_magento_url_keys>
+                        <heading_configurable_products translate="label">
+                            <label>Configurable products</label>
+                            <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+                            <sort_order>199</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </heading_configurable_products>
                         <configurable_children_use_simple_price>
-                            <label>Configurable children - use price from simple products</label>
+                            <label>Use price from simple products</label>
                             <comment>Select yes if you calculate price base on simple products. By default Magento 1 does not support this.</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
@@ -242,6 +250,16 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </configurable_children_use_simple_price>
+                        <configurable_children_use_image_inheritance>
+                            <label>Inherit product image</label>
+                            <comment>If any image is missing on the simple product, this will make it inherit the corresponding image from the parent product.</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>210</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </configurable_children_use_image_inheritance>
                     </fields>
                 </catalog_settings>
             </groups>


### PR DESCRIPTION
Adds a feature toggle that allows simple products inherit the images of the configurable product if they are missing, as requested in issue #15.

This PR also groups the catalog settings for configurable products by adding a heading.