### PR TITLE
Reflecting stock_status in is_in_stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Fixed CMS Block and Page identifier to avoid `-` tokenization - @mtarld (#22)
-- `stock_status` is now taken into consideration for the value of the synchronized value of `is_in_stock` for configurable products, this makes product listings in Vue Storefront better reflect the ones in native Magento - [@indiebytes](https://github.com/indiebytes) [#24](https://github.com/DivanteLtd/magento1-vsbridge-indexer/pull/24)
+- `stock_status` is now taken into consideration for the value of the synchronized value of `is_in_stock` for configurable products, this makes product listings in Vue Storefront better reflect the ones in native Magento - [@indiebytes](https://github.com/indiebytes) [(#24)](https://github.com/DivanteLtd/magento1-vsbridge-indexer/pull/24)
 
 ## [1.0.0] (2019.04.09)
 First version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 
 ### Fixed
-
+- `stock_status` is now taken into consideration for the value of the synchronized value of `is_in_stock` for configurable products, this makes product listings in Vue Storefront better reflect the ones in native Magento - [@indiebytes](https://github.com/indiebytes) [#24](https://github.com/DivanteLtd/magento1-vsbridge-indexer/pull/24)
 
 ## [1.0.0] (2019.04.09)
 First version

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Configurable.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Configurable.php
@@ -300,8 +300,9 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
                 $productStockStatus = $indexData[$productId]['stock']['stock_status'];
                 $isInStock = $indexData[$productId]['stock']['is_in_stock'];
 
-                if (!$isInStock || ($productStockStatus && !$areChildInStock)) {
+                if (!$isInStock || !$productStockStatus || ($productStockStatus && !$areChildInStock)) {
                     $indexData[$productId]['stock']['stock_status'] = 0;
+                    $indexData[$productId]['stock']['is_in_stock'] = 0;
                 }
 
                 $indexData[$productId]['configurable_options'][] = $productAttribute;


### PR DESCRIPTION
Filters in Vue Storefront look at at `is_in_stock`. In cases where a configurable product has `stock_status` set to `0` `is_in_stock` set to `1`, the product will be visible in Vue Storefront but not in Magento frontend. By forcing `is_in_stock` to `0` like in this commit we get a more expected result with the same product listing output as in Magento.

This resolves issue #23.