### PR TITLE
Support Elasticsearch host without port and bugfix for HTTPS enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## [Unreleased]
 
 ### Added
+- Allow to use Elasticsearch host without specific port - @cewald (#25)
 
 ### Fixed
 - Fixed CMS Block and Page identifier to avoid `-` tokenization - @mtarld (#22)
+- Always wrong scheme after enabling HTTPS in backend - @cewald (#25)
 
 ## [1.0.0] (2019.04.09)
 First version

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php
@@ -51,7 +51,7 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Builder
     {
         $scheme = 'http';
 
-        if (isset($options['enable_https_mode'])) {
+        if (isset($options['enable_https_mode']) && $options['enable_https_mode'] !== false) {
             $scheme = 'https';
         } elseif (isset($options['schema'])) {
             $scheme = $options['schema'];

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php
@@ -53,8 +53,8 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Builder
 
         if (isset($options['enable_https_mode']) && $options['enable_https_mode'] !== false) {
             $scheme = 'https';
-        } elseif (isset($options['schema'])) {
-            $scheme = $options['schema'];
+        } elseif (isset($options['scheme'])) {
+            $scheme = $options['scheme'];
         }
 
         $currentHostConfig = [

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php
@@ -17,7 +17,6 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Builder
      */
     private $defaultOptions = [
         'host' => 'localhost',
-        'port' => '9200',
         'enable_http_auth' => false,
         'auth_user' => null,
         'auth_pwd' => null,

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Configuration.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Configuration.php
@@ -83,12 +83,16 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Configuration
     {
         $options = [
             'host' => $this->getHost(),
-            'port' => $this->getPort(),
             'scheme' => $this->getScheme(),
+            'enable_https_mode' => (bool) $this->getConfigParam('enable_https_mode'),
             'enable_http_auth' => $this->isHttpAuthEnabled(),
             'auth_user' => $this->getHttpAuthUser(),
             'auth_pwd' => $this->getHttpAuthPassword(),
         ];
+
+        if (!empty($this->getPort())) {
+            $options['port'] = $this->getPort();
+        }
 
         return $options;
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Configuration.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Configuration.php
@@ -84,7 +84,6 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Configuration
         $options = [
             'host' => $this->getHost(),
             'scheme' => $this->getScheme(),
-            'enable_https_mode' => (bool) $this->getConfigParam('enable_https_mode'),
             'enable_http_auth' => $this->isHttpAuthEnabled(),
             'auth_user' => $this->getHttpAuthUser(),
             'auth_pwd' => $this->getHttpAuthPassword(),

--- a/src/app/code/community/Divante/VueStorefrontIndexer/etc/system.xml
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/etc/system.xml
@@ -64,7 +64,6 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                            <validate>required-entry</validate>
                         </port>
                         <enable_https_mode>
                             <label>Use HTTPS</label>


### PR DESCRIPTION
If you're using an ElasticSearch instance wich doesn't need a specific port, you can't configure it in the Magento backend yet, because the port field is always required. A common use case for this is if you're using Amazon ES as your Elasticsearch cluster of choice.

Also, if you enable HTTPS in configs, the class `Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Configuration` won't give the correct scheme because the option `enable_https_mode` is missing wich is been asked for in `Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Builder::getHost()`.

I fixed both.

Despite the fact that `9200` isn't the default port anymore [in the code](https://github.com/DivanteLtd/magento1-vsbridge-indexer/blob/develop/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php#L20), it's still the default value in the `/etc/config.xml`, so if you don't change anything it's still preset.