### PR TITLE
#37 Use `protected` method scope to make class overwrites easier

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Cache/Processor.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Cache/Processor.php
@@ -14,22 +14,22 @@ class Divante_VueStorefrontIndexer_Model_Cache_Processor
     /**
      * @var Divante_VueStorefrontIndexer_Model_Cache_Settings
      */
-    private $settings;
+    protected $settings;
     /**
      * @var Divante_VueStorefrontIndexer_Model_Cache_Logger
      */
-    private $logger;
+    protected $logger;
     /**
      * @var array
      */
-    private $defaultCacheTags = [
+    protected $defaultCacheTags = [
         'category' => 'C',
         'product' => 'P',
     ];
     /**
      * @var array
      */
-    private $cacheTags;
+    protected $cacheTags;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Observer_Cache constructor.
@@ -89,7 +89,7 @@ class Divante_VueStorefrontIndexer_Model_Cache_Processor
      * @param string $storeId
      * @param string $uri
      */
-    private function call($storeId, $uri)
+    protected function call($storeId, $uri)
     {
         $http = new Varien_Http_Adapter_Curl();
         $config = $this->settings->getConnectionOptions($storeId);
@@ -112,7 +112,7 @@ class Divante_VueStorefrontIndexer_Model_Cache_Processor
      *
      * @return string
      */
-    private function getCacheInvalidateUrl($storeId, $type, array $ids)
+    protected function getCacheInvalidateUrl($storeId, $type, array $ids)
     {
         $fullUrl = $this->getInvalidateCacheUrl($storeId);
         $params = $this->prepareTagsByDocIds($type, $ids);
@@ -124,7 +124,7 @@ class Divante_VueStorefrontIndexer_Model_Cache_Processor
     /**
      * @return string
      */
-    private function getInvalidateCacheUrl($storeId)
+    protected function getInvalidateCacheUrl($storeId)
     {
         $url = $this->settings->getVsfBaseUrl($storeId);
         $url .= sprintf('invalidate?key=%s&tag=', $this->settings->getInvalidateCacheKey($storeId));

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Data/Filter.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Data/Filter.php
@@ -15,7 +15,7 @@ class Divante_VueStorefrontIndexer_Model_Data_Filter
     /**
      * @var array
      */
-    private $longProperties = [];
+    protected $longProperties = [];
 
     /**
      * Divante_VueStorefrontIndexer_Model_Data_Filter constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Data/Gallery.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Data/Gallery.php
@@ -42,7 +42,7 @@ class Divante_VueStorefrontIndexer_Model_Data_Gallery
      *
      * @return string
      */
-    private function getValue($fieldKey, array $image)
+    protected function getValue($fieldKey, array $image)
     {
         if (isset($image[$fieldKey]) && (null !== $image[$fieldKey])) {
             return $image[$fieldKey];

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client.php
@@ -21,7 +21,7 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client
     /**
      * @var \Elasticsearch\Client|null
      */
-    private $esClient = null;
+    protected $esClient = null;
 
     /**
      * Divante_VueStorefrontIndexer_Model_ElasticSearch_Client constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Builder.php
@@ -15,7 +15,7 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Builder
     /**
      * @var array
      */
-    private $defaultOptions = [
+    protected $defaultOptions = [
         'host' => 'localhost',
         'enable_http_auth' => false,
         'auth_user' => null,
@@ -47,7 +47,7 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Builder
      *
      * @return array
      */
-    private function getHost(array $options)
+    protected function getHost(array $options)
     {
         $scheme = 'http';
 

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Configuration.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Client/Configuration.php
@@ -69,7 +69,7 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Client_Configuration
      *
      * @return string|null
      */
-    private function getConfigParam($configField)
+    protected function getConfigParam($configField)
     {
         $path = self::ES_CLIENT_CONFIG_XML_PREFIX . '/' . $configField;
 

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Indexer/Handler.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Elasticsearch/Indexer/Handler.php
@@ -20,37 +20,37 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Indexer_Handler
     /**
      * @var IndexOperation
      */
-    private $indexOperation;
+    protected $indexOperation;
 
     /**
      * @var Client
      */
-    private $client;
+    protected $client;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Cache_Processor
      */
-    private $cacheProcessor;
+    protected $cacheProcessor;
 
     /**
      * @var string
      */
-    private $typeName;
+    protected $typeName;
 
     /**
      * @var string
      */
-    private $indexIdentifier;
+    protected $indexIdentifier;
 
     /**
      * @var int|string
      */
-    private $transactionKey;
+    protected $transactionKey;
 
     /**
      * @var ConvertDataTypes
      */
-    private $convertDataTypes;
+    protected $convertDataTypes;
 
     /**
      * constructor.
@@ -242,7 +242,7 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Indexer_Handler
      *
      * @return Divante_VueStorefrontIndexer_Model_Index_Index
      */
-    private function getIndex(Store $store)
+    protected function getIndex(Store $store)
     {
         try {
             $index = $this->indexOperation->getIndexByName($this->indexIdentifier, $store);
@@ -256,7 +256,7 @@ class Divante_VueStorefrontIndexer_Model_Elasticsearch_Indexer_Handler
     /**
      * @return int
      */
-    private function getBatchSize()
+    protected function getBatchSize()
     {
         return $this->indexOperation->getBatchIndexingSize();
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Event/Delete.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Event/Delete.php
@@ -17,7 +17,7 @@ class Divante_VueStoreFrontIndexer_Model_Event_Delete
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Event
      */
-    private $resource;
+    protected $resource;
 
     /**
      * Divante_VueStoreFrontIndexer_Model_Event_Delete constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Bulkrequest.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Bulkrequest.php
@@ -18,7 +18,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Bulkrequest implements BulkReques
      *
      * @var array
      */
-    private $bulkData = [];
+    protected $bulkData = [];
 
     /**
      * @inheritdoc
@@ -35,7 +35,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Bulkrequest implements BulkReques
     /**
      * @inheritdoc
      */
-    private function deleteDocument($index, $type, $docId)
+    protected function deleteDocument($index, $type, $docId)
     {
         $this->bulkData[] = [
             'delete' => [
@@ -63,7 +63,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Bulkrequest implements BulkReques
     /**
      * @inheritdoc
      */
-    private function addDocument($index, $type, $docId, array $data)
+    protected function addDocument($index, $type, $docId, array $data)
     {
         $this->bulkData[] = [
             'index' => [
@@ -93,7 +93,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Bulkrequest implements BulkReques
     /**
      * @inheritdoc
      */
-    private function updateDocument($index, $type, $docId, array $data)
+    protected function updateDocument($index, $type, $docId, array $data)
     {
         $this->bulkData[] = [
             'update' => [

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Bulkresponse.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Bulkresponse.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Bulkresponse implements BulkRespo
     /**
      * @var array
      */
-    private $rawResponse;
+    protected $rawResponse;
 
     /**
      * Constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Convertdatatypes.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Convertdatatypes.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Convertdatatypes
     /**
      * @var array
      */
-    private $castMapping = [
+    protected $castMapping = [
         'integer' => 'int',
         'text' => 'string',
         'long' => 'int',
@@ -68,7 +68,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Convertdatatypes
      *
      * @return array
      */
-    private function convert(array $indexData, array $mappingProperties)
+    protected function convert(array $indexData, array $mappingProperties)
     {
         foreach ($mappingProperties as $fieldKey => $options) {
             if (isset($options['type'])) {
@@ -95,7 +95,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Convertdatatypes
      *
      * @return array
      */
-    private function convertChildrenData(array $category, $mappingProperties)
+    protected function convertChildrenData(array $category, $mappingProperties)
     {
         $childrenData = $category['children_data'];
 
@@ -114,7 +114,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Convertdatatypes
      *
      * @return string|null
      */
-    private function getCastType($esFieldType)
+    protected function getCastType($esFieldType)
     {
         if (isset($this->castMapping[$esFieldType])) {
             return $this->castMapping[$esFieldType];

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Index.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Index.php
@@ -17,14 +17,14 @@ class Divante_VueStorefrontIndexer_Model_Index_Index
      *
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * Index types.
      *
      * @var
      */
-    private $types;
+    protected $types;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Index_Index constructor.
@@ -47,7 +47,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Index
      *
      * @return array
      */
-    private function prepareTypes(array $types)
+    protected function prepareTypes(array $types)
     {
         $preparedTypes = [];
 

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Attribute.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Attribute.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Attribute implements Mapp
     /**
      * @var array
      */
-    private $booleanProperties = [
+    protected $booleanProperties = [
         'is_required',
         'is_user_defined',
         'is_unique',
@@ -40,7 +40,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Attribute implements Mapp
     /**
      * @var array
      */
-    private $longProperties = [
+    protected $longProperties = [
         'attribute_id',
         'id',
         'is_filterable',
@@ -52,7 +52,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Attribute implements Mapp
     /**
      * @var array
      */
-    private $stringProperties  = [
+    protected $stringProperties  = [
         'attribute_code',
         'attribute_model',
         'backend_model',
@@ -71,7 +71,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Attribute implements Mapp
     /**
      * @var string
      */
-    private $type;
+    protected $type;
 
     /**
      * @inheritdoc

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Category.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Category.php
@@ -19,12 +19,12 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Category extends Abstract
     /**
      * @var string
      */
-    private $type;
+    protected $type;
 
     /**
      * @var array
      */
-    private $properties;
+    protected $properties;
 
     /**
      * @inheritdoc

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Cms/Block.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Cms/Block.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Cms_Block implements Mapp
     /**
      * @var string
      */
-    private $type;
+    protected $type;
 
     /**
      * @inheritdoc

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Eav/Abstract.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Eav/Abstract.php
@@ -34,7 +34,7 @@ abstract class Divante_VueStorefrontIndexer_Model_Index_Mapping_Eav_Abstract
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * @return string

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Generalmapping.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Generalmapping.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Generalmapping
     /**
      * @var array
      */
-    private $commonProperties = [
+    protected $commonProperties = [
         'position' => ['type' => FieldInterface::TYPE_LONG],
         'level' => ['type' => FieldInterface::TYPE_LONG],
         'created_at' => [

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Product.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Product.php
@@ -21,12 +21,12 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Product extends AbstractM
     /**
      * @var string
      */
-    private $type;
+    protected $type;
 
     /**
      * @var array
      */
-    private $properties;
+    protected $properties;
 
     /**
      * @inheritdoc
@@ -106,7 +106,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Product extends AbstractM
     /**
      * @return array
      */
-    private function getCustomProperties()
+    protected function getCustomProperties()
     {
         return [
             'attribute_set_id' => ['type' => FieldInterface::TYPE_LONG],

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Review.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Review.php
@@ -20,12 +20,12 @@ class Divante_VueStorefrontIndexer_Model_Index_Mapping_Review implements Mapping
     /**
      * @var string
      */
-    private $type;
+    protected $type;
 
     /**
      * @var array
      */
-    private $properties;
+    protected $properties;
 
     /**
      * @inheritdoc

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Operations.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Operations.php
@@ -22,22 +22,22 @@ class Divante_VueStorefrontIndexer_Model_Index_Operations
     /**
      * @var Client
      */
-    private $client;
+    protected $client;
 
     /**
      * @var IndexSettings
      */
-    private $indexSettings;
+    protected $indexSettings;
 
     /**
      * @var array
      */
-    private $indicesConfiguration;
+    protected $indicesConfiguration;
 
     /**
      * @var array
      */
-    private $indicesByName;
+    protected $indicesByName;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Index_Operations constructor.
@@ -230,7 +230,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Operations
      *
      * @return Index
      */
-    private function initIndex($indexIdentifier, Store $store)
+    protected function initIndex($indexIdentifier, Store $store)
     {
         if (!isset($this->indicesConfiguration[$indexIdentifier])) {
             throw new \LogicException("No configuration found");

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Settings.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Settings.php
@@ -70,7 +70,7 @@ class Divante_VueStorefrontIndexer_Model_Index_Settings
      *
      * @return array
      */
-    private function initIndicesConfig(array $indexConfigData)
+    protected function initIndicesConfig(array $indexConfigData)
     {
         $types = [];
 

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Type.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Type.php
@@ -18,21 +18,21 @@ class Divante_VueStorefrontIndexer_Model_Index_Type implements TypeInterface
      *
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * Type mapping.
      *
      * @var \Divante_VueStorefrontIndexer_Api_MappingInterface|null
      */
-    private $mapping;
+    protected $mapping;
 
     /**
      * Type datasources.
      *
      * @var \Divante_VueStorefrontIndexer_Api_DatasourceInterface[]
      */
-    private $dataSources;
+    protected $dataSources;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Index_Type constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Attribute.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Attribute.php
@@ -14,7 +14,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Attribute
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Attribute_Full constructor.
@@ -52,7 +52,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Attribute
      *
      * @return array
      */
-    private function filterData(array $attributeData)
+    protected function filterData(array $attributeData)
     {
         if (isset($attributeData['position'])) {
             $attributeData['position'] = (int)$attributeData['position'];

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Category.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Category.php
@@ -15,7 +15,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Category
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Category constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Cms/Block.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Cms/Block.php
@@ -14,12 +14,12 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Cms_Block
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Cms_Block
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * @var Varien_Filter_Template
      */
-    private $blockTemplateProcessor;
+    protected $blockTemplateProcessor;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Cms_Block constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Product.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Product.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Product
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Data_Filter
      */
-    private $dataFilter;
+    protected $dataFilter;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Category_Full constructor.
@@ -75,7 +75,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Product
      *
      * @return mixed
      */
-    private function filterData(array $productData)
+    protected function filterData(array $productData)
     {
         return $this->dataFilter->execute($productData);
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Reviews.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Reviews.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Reviews
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Review
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Data_Filter
      */
-    private $dataFilter;
+    protected $dataFilter;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Category_Full constructor.
@@ -63,7 +63,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Reviews
      *
      * @return mixed
      */
-    private function filterData(array $reviewData)
+    protected function filterData(array $reviewData)
     {
         return $this->dataFilter->execute($reviewData);
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Taxrule.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Action/Taxrule.php
@@ -14,7 +14,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Action_Taxrule
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Tax_Rules
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Taxrule constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Attributes.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Attributes.php
@@ -22,17 +22,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Attributes implements IndexerIn
     /**
      * @var IndexerHandler
      */
-    private $indexHandler;
+    protected $indexHandler;
 
     /**
      * @var AttributeAction
      */
-    private $action;
+    protected $action;
 
     /**
      * @var StoreHelper
      */
-    private $storeHelper;
+    protected $storeHelper;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Attribute constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Categories.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Categories.php
@@ -22,17 +22,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Categories implements IndexerIn
     /**
      * @var IndexerHandler
      */
-    private $indexHandler;
+    protected $indexHandler;
 
     /**
      * @var CategoryAction
      */
-    private $action;
+    protected $action;
 
     /**
      * @var StoreHelper
      */
-    private $storeHelper;
+    protected $storeHelper;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Category constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Cms/Blocks.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Cms/Blocks.php
@@ -22,17 +22,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Cms_Blocks implements IndexerIn
     /**
      * @var IndexerHandler
      */
-    private $indexHandler;
+    protected $indexHandler;
 
     /**
      * @var Action
      */
-    private $action;
+    protected $action;
 
     /**
      * @var StoreHelper
      */
-    private $storeHelper;
+    protected $storeHelper;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Cms_Blocks constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Attribute/Options.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Attribute/Options.php
@@ -116,7 +116,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Attribute_Options im
      *
      * @return bool
      */
-    private function useSource(array $attributeData)
+    protected function useSource(array $attributeData)
     {
         return $attributeData['frontend_input'] === 'select' || $attributeData['frontend_input'] === 'multiselect'
                || $attributeData['source_model'] != '';
@@ -127,7 +127,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Attribute_Options im
      *
      * @return array
      */
-    private function getStoreLabelsByAttributeId($attributeId)
+    protected function getStoreLabelsByAttributeId($attributeId)
     {
         /** @var Mage_Eav_Model_Resource_Entity_Attribute $attributeResource */
         $attributeResource = Mage::getResourceModel('eav/entity_attribute');

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Category/Attributes.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Category/Attributes.php
@@ -18,7 +18,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes 
     /**
      * @var array
      */
-    private $fieldsToDelete = [
+    protected $fieldsToDelete = [
         'entity_id',
         'entity_type_id',
         'attribute_set_id',
@@ -30,7 +30,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes 
     /**
      * @var array
      */
-    private $longProperties = [
+    protected $longProperties = [
         'level',
         'id',
         'parent_id',
@@ -41,32 +41,32 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category_Attributes
      */
-    private $attributeResourceModel;
+    protected $attributeResourceModel;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category_Children
      */
-    private $childrenResourceModel;
+    protected $childrenResourceModel;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Data_Filter
      */
-    private $dataFilter;
+    protected $dataFilter;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Config_Catalogsettings
      */
-    private $settings;
+    protected $settings;
 
     /**
      * @var SlugGenerator
      */
-    private $slugGenerator;
+    protected $slugGenerator;
 
     /**
      * @var array
      */
-    private $childrenRowAttributes = [];
+    protected $childrenRowAttributes = [];
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes constructor.
@@ -120,7 +120,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes 
      *
      * @return array
      */
-    private function sortChildrenById(array $children)
+    protected function sortChildrenById(array $children)
     {
         $sortChildrenById = [];
 
@@ -138,7 +138,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes 
      *
      * @return array
      */
-    private function plotTree(array $categories, $rootId)
+    protected function plotTree(array $categories, $rootId)
     {
         $return = [];
 
@@ -171,7 +171,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes 
      *
      * @return array
      */
-    private function prepareCategory(array $categoryDTO)
+    protected function prepareCategory(array $categoryDTO)
     {
         $categoryDTO = $this->addSlug($categoryDTO);
         $categoryDTO['id'] = intval($categoryDTO['entity_id']);
@@ -189,7 +189,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes 
      *
      * @return array
      */
-    private function addSlug(array $categoryDTO)
+    protected function addSlug(array $categoryDTO)
     {
         if ($this->settings->useMagentoUrlKeys()) {
             if (!isset($categoryDTO['url_key'])) {
@@ -215,7 +215,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Attributes 
      *
      * @return array
      */
-    private function filterData(array $categoryData)
+    protected function filterData(array $categoryData)
     {
         return $this->dataFilter->execute($categoryData, $this->fieldsToDelete);
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Category/Gridperpage.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Category/Gridperpage.php
@@ -34,7 +34,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Category_Gridperpage
      *
      * @return int
      */
-    private function getDefaultGridPerPageValue($storeId)
+    protected function getDefaultGridPerPageValue($storeId)
     {
         return (int)Mage::getStoreConfig('catalog/frontend/grid_per_page', $storeId);
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Attributes.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Attributes.php
@@ -18,17 +18,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Attributes i
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Attributes
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Config_Catalogsettings
      */
-    private $settings;
+    protected $settings;
 
     /**
      * @var SlugGenerator
      */
-    private $slugGenerator;
+    protected $slugGenerator;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Attributes constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Bundle.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Bundle.php
@@ -16,7 +16,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Bundle imple
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Bundle constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Categories.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Categories.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Categories i
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Category
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * Constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Configurable.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Configurable.php
@@ -18,11 +18,11 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
     /**
      * @var int
      */
-    private $batchSize = 500;
+    protected $batchSize = 500;
     /**
      * @var array
      */
-    private $childBlackListConfig = [
+    protected $childBlackListConfig = [
         'entity_id',
         'parent_id',
         'parent_ids',
@@ -33,7 +33,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      * (depends on number of child/parent number, and number of required attributes)
      * @var array
      */
-    private $requireChildrenAttributes = [
+    protected $requireChildrenAttributes = [
         'name',
         'small_image',
         'thumbnail',
@@ -47,7 +47,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      * Images
      * @var array
      */
-    private $imageAttributes = [
+    protected $imageAttributes = [
         'image',
         'small_image',
         'thumbnail'
@@ -55,27 +55,27 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
     /**
      * @var Divante_VueStorefrontIndexer_Model_Data_Filter
      */
-    private $dataFilter;
+    protected $dataFilter;
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      */
-    private $configurableResource;
+    protected $configurableResource;
     /**
      * @var  Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Attributes
      */
-    private $resourceAttributeModel;
+    protected $resourceAttributeModel;
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Inventory
      */
-    private $inventoryResource;
+    protected $inventoryResource;
     /**
      * @var GeneralMapping
      */
-    private $generalMapping;
+    protected $generalMapping;
     /**
      * @var Divante_VueStorefrontIndexer_Model_Config_Catalogsettings
      */
-    private $configSettings;
+    protected $configSettings;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Category_Full constructor.
@@ -114,7 +114,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      * @throws Mage_Core_Exception
      * @throws Mage_Core_Model_Store_Exception
      */
-    private function prepareConfigurableChildrenAttributes(array $indexData, $storeId)
+    protected function prepareConfigurableChildrenAttributes(array $indexData, $storeId)
     {
         $allChildren = $this->configurableResource->getSimpleProducts($storeId);
 
@@ -204,7 +204,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      *
      * @return float
      */
-    private function getNotifyForQtyBelowDefaultValue($storeId)
+    protected function getNotifyForQtyBelowDefaultValue($storeId)
     {
         return (float)Mage::getStoreConfig(Mage_CatalogInventory_Model_Stock_Item::XML_PATH_NOTIFY_STOCK_QTY, $storeId);
     }
@@ -236,7 +236,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      *
      * @return array
      */
-    private function addConfigurableAttributes(array $indexData)
+    protected function addConfigurableAttributes(array $indexData)
     {
         foreach ($indexData as $productId => $productDTO) {
             if (!isset($productDTO['configurable_children'])) {
@@ -345,7 +345,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      *
      * @return float|int
      */
-    private function calcSelectionPrice(array $priceInfo, $productPrice)
+    protected function calcSelectionPrice(array $priceInfo, $productPrice)
     {
         if ($priceInfo['is_percent']) {
             $ratio = floatval($priceInfo['pricing_value']) / 100;
@@ -364,7 +364,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      *
      * @return mixed
      */
-    private function loadChildrenRawAttributesInBatches($storeId, array $allChildren, array $requiredAttributes)
+    protected function loadChildrenRawAttributesInBatches($storeId, array $allChildren, array $requiredAttributes)
     {
         $requiredAttribute = array_unique($requiredAttributes);
         $childIds = [];
@@ -417,7 +417,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      *
      * @return array
      */
-    private function filterData(array $productData)
+    protected function filterData(array $productData)
     {
         return $this->dataFilter->execute($productData, $this->childBlackListConfig);
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Inventory.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Inventory.php
@@ -18,12 +18,12 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Inventory im
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Inventory
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var GeneralMapping
      */
-    private $generalMapping;
+    protected $generalMapping;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Category_Full constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Links.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Links.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Links implem
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
      */
-    private $linkedProductResource;
+    protected $linkedProductResource;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Links constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Media.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Media.php
@@ -17,12 +17,12 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Media implem
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Media
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Data_Gallery
      */
-    private $galleryData;
+    protected $galleryData;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Links constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Prices.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Prices.php
@@ -17,17 +17,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Prices imple
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Prices
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Tiers
      */
-    private $tiersResource;
+    protected $tiersResource;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Groupprices
      */
-    private $groupPriceResource;
+    protected $groupPriceResource;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Tiers constructor.
@@ -113,7 +113,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Prices imple
      *
      * @return array
      */
-    private function prepareTierPrices(array $productTierPrice)
+    protected function prepareTierPrices(array $productTierPrice)
     {
         return [
             'customer_group_id' => (int)$productTierPrice['cust_group'],
@@ -131,7 +131,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Prices imple
      * @return int
      * @throws Mage_Core_Model_Store_Exception
      */
-    private function getWebsiteId($storeId)
+    protected function getWebsiteId($storeId)
     {
         $attribute = $this->getTierPriceAttribute();
         $websiteId = 0;
@@ -148,7 +148,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Prices imple
     /**
      * @return Mage_Catalog_Model_Resource_Eav_Attribute
      */
-    private function getTierPriceAttribute()
+    protected function getTierPriceAttribute()
     {
         /** @var Mage_Catalog_Model_Resource_Eav_Attribute $attributeModel */
         $attributeModel = Mage::getSingleton('eav/config')->getAttribute('catalog_product', 'tier_price');

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Tax/Rates.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Tax/Rates.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Tax_Rates implements
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Tax_Rates
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Taxrule constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Tax/Taxclasses.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Tax/Taxclasses.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Tax_Taxclasses imple
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Tax_Taxclasses
      */
-    private $resourceModel;
+    protected $resourceModel;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Action_Taxrule constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Helper/Store.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Helper/Store.php
@@ -15,7 +15,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Helper_Store
     /**
      * @var Divante_VueStorefrontIndexer_Model_Config_Generalsettings
      */
-    private $configSettings;
+    protected $configSettings;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Partialupdate/Category/Gridperpage.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Partialupdate/Category/Gridperpage.php
@@ -23,17 +23,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Partialupdate_Category_Gridperp
     /**
      * @var IndexerHandler
      */
-    private $indexHandler;
+    protected $indexHandler;
 
     /**
      * @var CategoryAction
      */
-    private $action;
+    protected $action;
 
     /**
      * @var StoreHelper
      */
-    private $storeHelper;
+    protected $storeHelper;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Category constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Productcategories.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Productcategories.php
@@ -24,17 +24,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Productcategories implements In
     /**
      * @var IndexerHandler
      */
-    private $indexHandler;
+    protected $indexHandler;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Indexer_Action_Product
      */
-    private $action;
+    protected $action;
 
     /**
      * @var StoreHelper
      */
-    private $storeHelper;
+    protected $storeHelper;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Attribute constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Products.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Products.php
@@ -21,17 +21,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Products implements IndexerInte
     /**
      * @var IndexerHandler
      */
-    private $indexHandler;
+    protected $indexHandler;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Indexer_Action_Product
      */
-    private $action;
+    protected $action;
 
     /**
      * @var StoreHelper
      */
-    private $storeHelper;
+    protected $storeHelper;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Attribute constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Reviews.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Reviews.php
@@ -21,17 +21,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Reviews implements IndexerInter
     /**
      * @var IndexerHandler
      */
-    private $indexHandler;
+    protected $indexHandler;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Indexer_Action_Reviews
      */
-    private $action;
+    protected $action;
 
     /**
      * @var StoreHelper
      */
-    private $storeHelper;
+    protected $storeHelper;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Reviews constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Taxrules.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Taxrules.php
@@ -21,17 +21,17 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Taxrules implements IndexerInte
     /**
      * @var IndexerHandler
      */
-    private $indexHandler;
+    protected $indexHandler;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Indexer_Action_Taxrule
      */
-    private $action;
+    protected $action;
 
     /**
      * @var StoreHelper
      */
-    private $storeHelper;
+    protected $storeHelper;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Indexer_Attribute constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Cache.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Cache.php
@@ -17,15 +17,15 @@ class Divante_VueStorefrontIndexer_Model_Observer_Cache
     /**
      * @var Divante_VueStorefrontIndexer_Model_Cache_Settings
      */
-    private $settings;
+    protected $settings;
     /**
      * @var Divante_VueStorefrontIndexer_Model_Cache_Logger
      */
-    private $logger;
+    protected $logger;
     /**
      * @var array
      */
-    private $cacheTags = [
+    protected $cacheTags = [
         'category' => 'C',
         'product'  => 'P',
     ];
@@ -97,7 +97,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Cache
      *
      * @return string
      */
-    private function getCacheInvalidateUrl($type, array $ids)
+    protected function getCacheInvalidateUrl($type, array $ids)
     {
         $baseUrl = $this->getInvalidateCacheUrl();
         $params = $this->prepareParams($type, $ids);
@@ -109,7 +109,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Cache
     /**
      * @return string
      */
-    private function getInvalidateCacheUrl()
+    protected function getInvalidateCacheUrl()
     {
         $url = $this->settings->getVsfBaseUrl();
         $url .= sprintf('invalidate?key=%s&tag=', $this->settings->getInvalidateCacheKey());
@@ -123,7 +123,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Cache
      *
      * @return string
      */
-    private function prepareParams($type, array $ids)
+    protected function prepareParams($type, array $ids)
     {
         $params = '';
 

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Attribute/Delete.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Attribute/Delete.php
@@ -18,7 +18,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Attribute_Delete
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Attribute/Save.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Attribute/Save.php
@@ -18,7 +18,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Attribute_Save
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Category/Delete.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Category/Delete.php
@@ -18,17 +18,17 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Category_Delete
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * @var Mage_Catalog_Model_Resource_Category
      */
-    private $categoryResource;
+    protected $categoryResource;
 
     /**
      * @var array
      */
-    private $logEvents = [];
+    protected $logEvents = [];
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Category/Save.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Category/Save.php
@@ -21,12 +21,12 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Category_Save
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Config_Generalsettings
      */
-    private $configSettings;
+    protected $configSettings;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.
@@ -75,7 +75,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Category_Save
     /**
      * @param Mage_Catalog_Model_Category $category
      */
-    private function updateParentCategories(Category $category)
+    protected function updateParentCategories(Category $category)
     {
         $path = $category->getPath();
         $categoryIds = explode('/', $path);

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Cms/Block/Delete.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Cms/Block/Delete.php
@@ -19,7 +19,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Cms_Block_Delete
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Cms/Block/Save.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Cms/Block/Save.php
@@ -19,7 +19,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Cms_Block_Save
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Product/Delete.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Product/Delete.php
@@ -19,27 +19,27 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Product_Delete
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * @var ParentResourceModel
      */
-    private $parentResourceModel;
+    protected $parentResourceModel;
 
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * @var array
      */
-    private $logEvents = [];
+    protected $logEvents = [];
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.
@@ -92,7 +92,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Product_Delete
     /**
      * @param Mage_Catalog_Model_Product $product
      */
-    private function updateParents(Product $product)
+    protected function updateParents(Product $product)
     {
         /**
          * Update parent product data

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Product/Mass/Update.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Product/Mass/Update.php
@@ -18,12 +18,12 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Product_Mass_Update
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * @var ParentResourceModel
      */
-    private $parentResourceModel;
+    protected $parentResourceModel;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.
@@ -59,7 +59,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Product_Mass_Update
     /**
      * @param array $productIds
      */
-    private function updateParents(array $productIds)
+    protected function updateParents(array $productIds)
     {
         if (!empty($productIds)) {
             $parentIds = $this->parentResourceModel->execute($productIds);
@@ -77,7 +77,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Product_Mass_Update
     /**
      * @param array $productIds
      */
-    private function saveLogs(array $productIds)
+    protected function saveLogs(array $productIds)
     {
         foreach ($productIds as $productId) {
             $this->logEvent(

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Product/Save.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Observer/Event/Product/Save.php
@@ -20,12 +20,12 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Product_Save
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * @var ParentResourceModel
      */
-    private $parentResourceModel;
+    protected $parentResourceModel;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.
@@ -82,7 +82,7 @@ class Divante_VueStorefrontIndexer_Model_Observer_Event_Product_Save
     /**
      * @param Mage_Catalog_Model_Product $product
      */
-    private function updateParents(Product $product)
+    protected function updateParents(Product $product)
     {
         if (Mage_Catalog_Model_Product_Type::TYPE_SIMPLE === $product->getTypeId()) {
             $productId = $product->getId();

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Attribute.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Attribute.php
@@ -16,12 +16,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Category.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Category.php
@@ -17,12 +17,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Category/Children.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Category/Children.php
@@ -15,17 +15,17 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category_Children
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * @var int
      */
-    private $isActiveAttributeId;
+    protected $isActiveAttributeId;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav constructor.
@@ -65,7 +65,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category_Children
      *
      * @return array
      */
-    private function getChildrenIds(array $category, $storeId, $recursive = true)
+    protected function getChildrenIds(array $category, $storeId, $recursive = true)
     {
         $attributeId = (int)$this->getIsActiveAttributeId();
         $backendTable = $this->coreResource->getTableName(
@@ -103,7 +103,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category_Children
      *
      * @return Varien_Db_Select
      */
-    private function getChildrenIdSelect(array $category, $recursive = true)
+    protected function getChildrenIdSelect(array $category, $recursive = true)
     {
         $path = $category['path'];
         $level = $category['level'];
@@ -124,7 +124,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category_Children
      *
      * @return int
      */
-    private function getIsActiveAttributeId()
+    protected function getIsActiveAttributeId()
     {
         if ($this->isActiveAttributeId === null) {
             $bind = array(

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Eav.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Eav.php
@@ -15,32 +15,32 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * @var
      */
-    private $attributeCollectionModel;
+    protected $attributeCollectionModel;
 
     /**
      * @var array
      */
-    private $attributesById;
+    protected $attributesById;
 
     /**
      * @var
      */
-    private $entityType;
+    protected $entityType;
 
     /**
      * @var
      */
-    private $valuesByEntityId;
+    protected $valuesByEntityId;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav constructor.
@@ -107,7 +107,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav
      *
      * @return bool
      */
-    private function canReindex($attribute, $allowedAttributes)
+    protected function canReindex($attribute, $allowedAttributes)
     {
         if ($attribute->isStatic()) {
             return false;
@@ -125,7 +125,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav
      *
      * @return array
      */
-    private function prepareValues(array $values)
+    protected function prepareValues(array $values)
     {
         foreach ($values as $value) {
             $entityId = $value['entity_id'];
@@ -145,7 +145,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav
     /**
      * @return Mage_Eav_Model_Entity_Type
      */
-    private function getEntityType()
+    protected function getEntityType()
     {
         /** @var Mage_Eav_Model_Entity_Type $entityType */
         $entityType = Mage::getModel('eav/entity_type')->loadByCode($this->entityType);
@@ -163,7 +163,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Eav
      *
      * @return Varien_Db_Select
      */
-    private function getLoadAttributesSelect($storeId, $table, array $attributeIds, array $entityIds)
+    protected function getLoadAttributesSelect($storeId, $table, array $attributeIds, array $entityIds)
     {
         $joinStoreCondition = [
             't_default.entity_id=t_store.entity_id',

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product.php
@@ -15,22 +15,22 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Config_Catalogsettings
      */
-    private $catalogSettings;
+    protected $catalogSettings;
 
     /**
      * @var int
      */
-    private $isActiveAttributeId;
+    protected $isActiveAttributeId;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.
@@ -111,7 +111,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product
      * @return Varien_Db_Select
      * @throws Mage_Core_Model_Store_Exception
      */
-    private function addWebsiteFilter(Varien_Db_Select $select, $storeId)
+    protected function addWebsiteFilter(Varien_Db_Select $select, $storeId)
     {
         $websiteId = Mage::app()->getStore($storeId)->getWebsiteId();
         $indexTable = $this->coreResource->getTableName('catalog_product_website');
@@ -132,7 +132,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product
      *
      * @return Varien_Db_Select
      */
-    private function addProductTypeFilter(Varien_Db_Select $select, $storeId)
+    protected function addProductTypeFilter(Varien_Db_Select $select, $storeId)
     {
         $types = $this->catalogSettings->getAllowedProductTypes($storeId);
 
@@ -169,7 +169,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product
      *
      * @return Varien_Db_Select
      */
-    private function addStatusFilter(Varien_Db_Select $select, $storeId)
+    protected function addStatusFilter(Varien_Db_Select $select, $storeId)
     {
         $backendTable = $this->coreResource->getTableName(
             [
@@ -209,7 +209,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product
      *
      * @return int
      */
-    private function getStatusAttributeId()
+    protected function getStatusAttributeId()
     {
         if ($this->isActiveAttributeId === null) {
             $bind = array(

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Bundle.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Bundle.php
@@ -15,27 +15,27 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * @var array
      */
-    private $products;
+    protected $products;
 
     /**
      * @var array
      */
-    private $bundleProductIds;
+    protected $bundleProductIds;
 
     /**
      * @var array
      */
-    private $bundleOptionsByProduct = [];
+    protected $bundleOptionsByProduct = [];
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links constructor.
@@ -89,7 +89,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
      *
      * @param int $storeId
      */
-    private function initOptions($storeId)
+    protected function initOptions($storeId)
     {
         $bundleOptions = $this->getBundleOptionsFromResource($storeId);
 
@@ -111,7 +111,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
     /**
      * Append Selection
      */
-    private function initSelection()
+    protected function initSelection()
     {
         $bundleSelections = $this->getBundleSelections();
         $simpleIds = array_column($bundleSelections, 'product_id');
@@ -142,7 +142,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
     /**
      * @return array
      */
-    private function getBundleSelections()
+    protected function getBundleSelections()
     {
         $productIds = $this->getBundleProductIds();
 
@@ -160,7 +160,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
      *
      * @return array
      */
-    private function getProductSku(array $productIds)
+    protected function getProductSku(array $productIds)
     {
         $select = $this->connection->select();
         $select->from($this->resource->getTableName('catalog/product'), ['entity_id', 'sku']);
@@ -174,7 +174,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
      *
      * @return array
      */
-    private function getBundleOptionsFromResource($storeId)
+    protected function getBundleOptionsFromResource($storeId)
     {
         $productIds = $this->getBundleProductIds();
 
@@ -197,7 +197,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
      *
      * @return Varien_Db_Select
      */
-    private function joinOptionValues(Varien_Db_Select $select, $storeId)
+    protected function joinOptionValues(Varien_Db_Select $select, $storeId)
     {
         $select
             ->joinLeft(
@@ -229,7 +229,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Bundle
     /**
      * @return array
      */
-    private function getBundleProductIds()
+    protected function getBundleProductIds()
     {
         if (null === $this->bundleProductIds) {
             $this->bundleProductIds = [];

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Category.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Category.php
@@ -15,22 +15,22 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Category
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Category
      */
-    private $categoryResource;
+    protected $categoryResource;
 
     /**
      * @var array Local cache for category names
      */
-    private $categoryNameCache = [];
+    protected $categoryNameCache = [];
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.
@@ -77,7 +77,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Category
      * @return array|mixed
      * @throws Mage_Core_Exception
      */
-    private function loadCategoryNames(array $categoryIds, $storeId)
+    protected function loadCategoryNames(array $categoryIds, $storeId)
     {
         $loadCategoryIds = $categoryIds;
 
@@ -106,7 +106,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Category
      * @return Varien_Db_Select
      * @throws Mage_Core_Exception
      */
-    private function prepareCategoryNameSelect(array $loadCategoryIds, $storeId)
+    protected function prepareCategoryNameSelect(array $loadCategoryIds, $storeId)
     {
         /** @var Mage_Catalog_Model_Resource_Category_Collection $categoryCollection */
         $categoryCollection = Mage::getResourceModel('catalog/category_collection');

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Configurable.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Configurable.php
@@ -19,14 +19,14 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      *
      * @var array
      */
-    private $configurableProductIds;
+    protected $configurableProductIds;
 
     /**
      * All associated simple products from configurables in $configurableProductIds
      *
      * @var array
      */
-    private $simpleProducts;
+    protected $simpleProducts;
 
     /**
      * Array of associated simple product ids.
@@ -35,7 +35,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      *
      * @var array
      */
-    private $associatedSimpleProducts;
+    protected $associatedSimpleProducts;
 
     /**
      * Array keys are the configurable product ids,
@@ -43,35 +43,35 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      *
      * @var array
      */
-    private $configurableProductAttributes;
+    protected $configurableProductAttributes;
 
     /**
      * @var array
      */
-    private $configurableAttributesInfo;
+    protected $configurableAttributesInfo;
 
     /**
      * @var array
      */
-    private $productsData;
+    protected $productsData;
     /**
      * @var
      */
-    private $superAttributeOptions;
+    protected $superAttributeOptions;
     /**
      * @var
      */
-    private $productSuperAttributeIds;
+    protected $productSuperAttributeIds;
 
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links constructor.
@@ -147,7 +147,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      *
      * @return array
      */
-    private function getConfigurableProductAttributes()
+    protected function getConfigurableProductAttributes()
     {
         if (!$this->configurableProductAttributes) {
             $productIds = $this->getConfigurableProductIds();
@@ -163,7 +163,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      *
      * @return array
      */
-    private function getSuperAttributePricing(array $superAttributeId)
+    protected function getSuperAttributePricing(array $superAttributeId)
     {
         $select = $this->connection->select()
             ->from(
@@ -191,7 +191,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      *
      * @return array
      */
-    private function getConfigurableAttributesForProductsFromResource(array $productIds)
+    protected function getConfigurableAttributesForProductsFromResource(array $productIds)
     {
         $select = $this->connection->select()
             ->from(
@@ -227,7 +227,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      *
      * @return array
      */
-    private function prepareConfigurableAttributesFullInfo()
+    protected function prepareConfigurableAttributesFullInfo()
     {
         if (null === $this->configurableAttributesInfo) {
             // build list of all configurable attribute codes for the current collection
@@ -277,7 +277,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      *
      * @return array
      */
-    private function getConfigurableProductIds()
+    protected function getConfigurableProductIds()
     {
         if (null === $this->configurableProductIds) {
             $this->configurableProductIds = array();

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Groupprices.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Groupprices.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Groupprices
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Stock constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Inventory.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Inventory.php
@@ -15,7 +15,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Inventory
     /**
      * @var array
      */
-    private $fields = [
+    protected $fields = [
         'product_id',
         'item_id',
         'stock_id',
@@ -46,12 +46,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Inventory
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Stock constructor.
@@ -104,7 +104,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Inventory
      * @return array
      * @throws Mage_Core_Model_Store_Exception
      */
-    private function getInventoryData($storeId, array $productIds, array $fields)
+    protected function getInventoryData($storeId, array $productIds, array $fields)
     {
         $websiteId = Mage::app()->getStore($storeId)->getWebsiteId();
 

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Links.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Links.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
      *
      * @var array
      */
-    private $typeMap = [
+    protected $typeMap = [
         Mage_Catalog_Model_Product_Link::LINK_TYPE_RELATED => 'related',
         Mage_Catalog_Model_Product_Link::LINK_TYPE_UPSELL => 'upsell',
         Mage_Catalog_Model_Product_Link::LINK_TYPE_CROSSSELL => 'crosssell',
@@ -27,27 +27,27 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
     /**
      * @var array
      */
-    private $products = [];
+    protected $products = [];
 
     /**
      * @var array
      */
-    private $links;
+    protected $links;
 
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * @var array
      */
-    private $positionAttribute;
+    protected $positionAttribute;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links constructor.
@@ -111,7 +111,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
      *
      * @return string|null
      */
-    private function getLinkType($typeId)
+    protected function getLinkType($typeId)
     {
         if (isset($this->typeMap[$typeId])) {
             return $this->typeMap[$typeId];
@@ -123,7 +123,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
     /**
      * @return array
      */
-    private function getAllLinkedProducts()
+    protected function getAllLinkedProducts()
     {
         if (null === $this->links) {
             $select = $this->prepareLinksSelect();
@@ -145,7 +145,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
     /**
      * @return Varien_Db_Select
      */
-    private function prepareLinksSelect()
+    protected function prepareLinksSelect()
     {
         $productIds = $this->getProductsIds();
 
@@ -177,7 +177,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
      *
      * @return Varien_Db_Select
      */
-    private function joinPositionAttribute(Varien_Db_Select $select)
+    protected function joinPositionAttribute(Varien_Db_Select $select)
     {
         $alias = 'link_position';
         $attributePosition = $this->fetchPositionAttributeData();
@@ -208,7 +208,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
     /**
      * @return array
      */
-    private function fetchPositionAttributeData()
+    protected function fetchPositionAttributeData()
     {
         if (null === $this->positionAttribute) {
             $select = $this->connection->select()
@@ -233,7 +233,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
      *
      * @return string
      */
-    private function getAttributeTypeTable($type)
+    protected function getAttributeTypeTable($type)
     {
         return 'catalog/product_link_attribute_' . $type;
     }
@@ -243,7 +243,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
      *
      * @return int[]
      */
-    private function getProductsIds()
+    protected function getProductsIds()
     {
         $products = $this->getProducts();
 
@@ -253,7 +253,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links
     /**
      * @return array
      */
-    private function getProducts()
+    protected function getProducts()
     {
         return $this->products;
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Media.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Media.php
@@ -17,12 +17,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Media
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links constructor.
@@ -49,7 +49,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Media
     /**
      * @return int
      */
-    private function getMediaGalleryAttributeId()
+    protected function getMediaGalleryAttributeId()
     {
         $attribute = Mage::getModel('eav/entity_attribute')
             ->loadByCode(Mage_Catalog_Model_Product::ENTITY, 'media_gallery');
@@ -63,7 +63,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Media
      *
      * @return Varien_Db_Select
      */
-    private function getLoadGallerySelect(array $productIds, $storeId)
+    protected function getLoadGallerySelect(array $productIds, $storeId)
     {
         $attributeId = $this->getMediaGalleryAttributeId();
         $adapter = $this->connection;

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Prices.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Prices.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Prices
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Stock constructor.
@@ -65,7 +65,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Prices
      * @return Mage_Core_Model_Store
      * @throws Mage_Core_Model_Store_Exception
      */
-    private function getStore($storeId)
+    protected function getStore($storeId)
     {
         return Mage::app()->getStore($storeId);
     }

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Relation/Parentids.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Relation/Parentids.php
@@ -33,7 +33,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Relation_Paren
      *
      * @return array
      */
-    private function getParentIds(array $productId)
+    protected function getParentIds(array $productId)
     {
         $configurableIds = Mage::getResourceSingleton('catalog/product_type_configurable')
             ->getParentIdsByChild($productId);

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Tiers.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Tiers.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Tiers
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $resource;
+    protected $resource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Tiers constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Review.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Review.php
@@ -14,17 +14,17 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Review
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * @var int
      */
-    private $isActiveAttributeId;
+    protected $isActiveAttributeId;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.
@@ -81,7 +81,7 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Review
      *
      * @return Varien_Db_Select
      */
-    private function joinReviewDetails(Varien_Db_Select $select)
+    protected function joinReviewDetails(Varien_Db_Select $select)
     {
         $backendTable = 'review_detail';
 

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Cms/Block.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Cms/Block.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Cms_Block
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Tax/Rates.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Tax/Rates.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Tax_Rates
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Tax/Rules.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Tax/Rules.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Tax_Rules
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Tax/Taxclasses.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Tax/Taxclasses.php
@@ -15,12 +15,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Tax_Taxclasses
     /**
      * @var Mage_Core_Model_Resource
      */
-    private $coreResource;
+    protected $coreResource;
 
     /**
      * @var Varien_Db_Adapter_Interface
      */
-    private $connection;
+    protected $connection;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Attribute_Full constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Sluggenerator.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Sluggenerator.php
@@ -30,7 +30,7 @@ class Divante_VueStorefrontIndexer_Model_Sluggenerator
      *
      * @return string
      */
-    private function slugify($text)
+    protected function slugify($text)
     {
         $text = mb_strtolower($text);
         $text = preg_replace("/\s+/", '-', $text);// Replace spaces with -

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/System/Config/Backend/Gridperpage.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/System/Config/Backend/Gridperpage.php
@@ -17,7 +17,7 @@ class Divante_VueStorefrontIndexer_Model_System_Config_Backend_Gridperpage exten
     /**
      * @var EventHandler
      */
-    private $eventHandler;
+    protected $eventHandler;
 
     /**
      * Divante_VueStoreFrontElasticSearch_Model_Observer_LogEventObserver constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Tools.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Tools.php
@@ -26,12 +26,12 @@ class Divante_VueStorefrontIndexer_Model_Tools
     /**
      * @var IndexOperation
      */
-    private $indexOperation;
+    protected $indexOperation;
 
     /**
      * @var deleteEvent
      */
-    private $deleteEvent;
+    protected $deleteEvent;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Tools constructor.
@@ -130,7 +130,7 @@ class Divante_VueStorefrontIndexer_Model_Tools
      *
      * @return bool
      */
-    private function runFullIndexing($entityType)
+    protected function runFullIndexing($entityType)
     {
         /** @var Divante_VueStorefrontIndexer_Model_Resource_Event_Collection $collection */
         $collection = Mage::getResourceModel('vsf_indexer/event_collection');
@@ -151,7 +151,7 @@ class Divante_VueStorefrontIndexer_Model_Tools
      * @param Divante_VueStorefrontIndexer_Api_IndexerInterface|Divante_VueStorefrontIndexer_Api_Indexer_UpdateInterface $indexerModel
      * @param int|null $storeId
      */
-    private function runPartialIndexing($indexerModel, $storeId = null)
+    protected function runPartialIndexing($indexerModel, $storeId = null)
     {
         $type = $indexerModel->getTypeName();
 
@@ -180,7 +180,7 @@ class Divante_VueStorefrontIndexer_Model_Tools
      *
      * @return array
      */
-    private function getUpdateEventLists($entityType, $eventType = 'save')
+    protected function getUpdateEventLists($entityType, $eventType = 'save')
     {
         $limit = $this->indexOperation->getBatchIndexingSize();
         /** @var Divante_VueStorefrontIndexer_Model_Resource_Event_Collection $collection */

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Tools/Index.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Tools/Index.php
@@ -16,7 +16,7 @@ class Divante_VueStorefrontIndexer_Model_Tools_Index
     /**
      * @var IndexOperation
      */
-    private $indexOperation;
+    protected $indexOperation;
 
     /**
      * Divante_VueStorefrontIndexer_Model_Tools constructor.

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Transactionkey.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Transactionkey.php
@@ -15,7 +15,7 @@ class Divante_VueStorefrontIndexer_Model_Transactionkey
     /**
      * @var int|string
      */
-    private $key;
+    protected $key;
 
     /**
      * @return int|string


### PR DESCRIPTION
> While I was overwriting some classes with a module of our own to keep this module "update-able", I noticed that there is by far every function is using the scope private. This makes it not possible to simply extend a class function by another without copying the whole class.
> 
> Is there a specific reason for that?
Otherwise I would suggest to change them to the protectedfunction scope.

See #37 