### PR TITLE
Bugfix for wrong prices of configurabled child products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes 
 - Export all tax rates ([#29](https://github.com/DivanteLtd/magento1-vsbridge-indexer/issues/29))
+- Wrong product-children website configurable prices when more than one website-price exists - @cewald (#46)
 
 ### Added
 - Export ratings for reviews

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Configurable.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Indexer/Datasource/Product/Configurable.php
@@ -116,7 +116,8 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
      */
     protected function prepareConfigurableChildrenAttributes(array $indexData, $storeId)
     {
-        $allChildren = $this->configurableResource->getSimpleProducts($storeId);
+        $this->configurableResource->setStoreId($storeId);
+        $allChildren = $this->configurableResource->getSimpleProducts();
 
         if (null === $allChildren) {
             return $indexData;
@@ -276,7 +277,7 @@ class Divante_VueStorefrontIndexer_Model_Indexer_Datasource_Product_Configurable
                         $priceInfo = $productAttribute['pricing'][$value];
                         $configurablePrice = $this->calcSelectionPrice($priceInfo, $childPrice);
                         $configurableChildren[$index]['price'] = $childPrice + $configurablePrice;
-
+                        
                         if ($specialPrice) {
                             $confSpecialPrice = $this->calcSelectionPrice($priceInfo, $specialPrice);
                             $configurableChildren[$index]['special_price'] = $specialPrice + $confSpecialPrice;

--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Configurable.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Resource/Catalog/Product/Configurable.php
@@ -54,10 +54,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      * @var array
      */
     private $productsData;
+
     /**
      * @var
      */
     private $superAttributeOptions;
+
     /**
      * @var
      */
@@ -74,12 +76,32 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
     private $connection;
 
     /**
+     * @var int
+     */
+    private $storeId;
+
+    /**
      * Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Links constructor.
      */
     public function __construct()
     {
         $this->resource = Mage::getSingleton('core/resource');
         $this->connection = $this->resource->getConnection('read');
+    }
+
+    /**
+     * @param int $storeId
+     * @return self
+     */
+    public function setStoreId($storeId)
+    {
+        $this->storeId = $storeId;
+        return $this;
+    }
+
+    protected function getStore()
+    {
+        return Mage::app()->getStore($this->storeId);
     }
 
     /**
@@ -165,6 +187,8 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      */
     private function getSuperAttributePricing(array $superAttributeId)
     {
+        $websiteId = $this->getStore()->getWebsite()->getId();
+
         $select = $this->connection->select()
             ->from(
                 $this->resource->getTableName('catalog/product_super_attribute_pricing'),
@@ -176,7 +200,8 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
                     'pricing_value',
                 ]
             )
-            ->where('product_super_attribute_id IN (?)', $superAttributeId);
+            ->where('product_super_attribute_id IN (?)', $superAttributeId)
+            ->where('website_id IN(?)', array($websiteId, 0));
 
         $attributes = $this->connection->fetchAssoc($select);
 
@@ -298,13 +323,12 @@ class Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product_Configurable
      * the current product collection.
      * Array key is the configurable product
      *
-     * @param int $storeId
-     *
      * @return array
      */
-    public function getSimpleProducts($storeId)
+    public function getSimpleProducts()
     {
         if (null === $this->simpleProducts) {
+            $storeId = $this->getStore()->getId();
             $parentIds = $this->getConfigurableProductIds();
             /** @var Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product $resource */
             $resource = Mage::getModel('Divante_VueStorefrontIndexer_Model_Resource_Catalog_Product');


### PR DESCRIPTION
If you don't use the `Use price from simple products` option and a product has different prices in different website, the wrong price is joined while indexing.

Thats why there isn't a `where` clause for the current website-id when the `catalog_product_super_attribute_pricing` is joined.

Yes indeed, thats a small and very specific bug – but I already wrote and tested the solution :)