### PR TITLE
Remove the outdated action `delete_indices`

### DIFF
--- a/src/shell/vsf_tools.php
+++ b/src/shell/vsf_tools.php
@@ -83,7 +83,6 @@ Usage:  php -f vsf_tools.php -- [options]
         --action <action_name>
                 full_reindex --store STORE_ID|OPTIONAL [--type categories|products|taxrules|attributes|cms_blocks|cms_pages|reviews]
                 reindex --store STORE_ID|OPTIONAL
-                delete_indices
 
 USAGE;
     }


### PR DESCRIPTION
Small change, but cosmetically nice: The option `delete_indices` is - as far as I can see - not needed, because you can accomplish the same thing by running a full reindex. But the option is still there in the help output. This PR removes it.