### PR TITLE
Fix boolean type mapping

### DIFF
--- a/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Eav/Abstract.php
+++ b/src/app/code/community/Divante/VueStorefrontIndexer/Model/Index/Mapping/Eav/Abstract.php
@@ -120,12 +120,12 @@ abstract class Divante_VueStorefrontIndexer_Model_Index_Mapping_Eav_Abstract
 
         $type = FieldInterface::TYPE_TEXT;
 
-        if ($attribute->getBackendType() == 'int' || $attribute->getFrontendClass() == 'validate-digits') {
+        if ($attribute->getSourceModel() == 'eav/entity_attribute_source_boolean') {
+            $type = FieldInterface::TYPE_BOOLEAN;
+        } elseif ($attribute->getBackendType() == 'int' || $attribute->getFrontendClass() == 'validate-digits') {
             $type = FieldInterface::TYPE_LONG;
         } elseif ($attribute->getBackendType() == 'decimal' || $attribute->getFrontendClass() == 'validate-number') {
             $type = FieldInterface::TYPE_DOUBLE;
-        } elseif ($attribute->getSourceModel() == 'eav/entity_attribute_source_boolean') {
-            $type = FieldInterface::TYPE_BOOLEAN;
         } elseif ($attribute->getBackendType() == 'datetime') {
             $type = FieldInterface::TYPE_DATE;
         } elseif ($attribute->usesSource()) {


### PR DESCRIPTION
Attributes with sourceModel "eav/entity_attribute_source_boolean" usually have backendType "int".

For example in the [core](https://github.com/OpenMage/magento-lts/blob/1.9.4.x/app/code/core/Mage/Catalog/sql/catalog_setup/mysql4-upgrade-1.4.0.0.27-1.4.0.0.28.php#L33).

And because those attributes are not always using an "is_" prefix, this code map them as "long".